### PR TITLE
change the data type of some int16_t variables.

### DIFF
--- a/ITG3200.cpp
+++ b/ITG3200.cpp
@@ -92,24 +92,24 @@ double ITG3200::getTemperature() {
 }
 /*Function: Get the contents of the registers in the ITG3200*/
 /*          so as to calculate the angular velocity.        */
-void ITG3200::getXYZ(int16_t* x, int16_t* y, int16_t* z) {
+void ITG3200::getXYZ(int* x, int* y, int* z) {
     *x = read(ITG3200_GX_H, ITG3200_GX_L) + x_offset;
     *y = read(ITG3200_GY_H, ITG3200_GY_L) + y_offset;
     *z = read(ITG3200_GZ_H, ITG3200_GZ_L) + z_offset;
 }
 /*Function: Get the angular velocity and its unit is degree per second.*/
 void ITG3200::getAngularVelocity(float* ax, float* ay, float* az) {
-    int16_t x, y, z;
+    int x, y, z;
     getXYZ(&x, &y, &z);
     *ax = x / 14.375;
     *ay = y / 14.375;
     *az = z / 14.375;
 }
 void ITG3200::zeroCalibrate(unsigned int samples, unsigned int sampleDelayMS) {
-    int16_t x_offset_temp = 0;
-    int16_t y_offset_temp = 0;
-    int16_t z_offset_temp = 0;
-    int16_t x, y, z;
+    long x_offset_temp = 0;
+    long y_offset_temp = 0;
+    long z_offset_temp = 0;
+    long x, y, z;
     x_offset = 0;
     y_offset = 0;
     z_offset = 0;

--- a/ITG3200.h
+++ b/ITG3200.h
@@ -54,7 +54,7 @@ class ITG3200 {
     int16_t read(uint8_t addressh, uint8_t addressl);
     void write(uint8_t _register, uint8_t _data);
     double getTemperature();
-    void getXYZ(int16_t* x, int16_t* y, int16_t* z);
+    void getXYZ(int* x, int* y, int* z);
     void getAngularVelocity(float* ax, float* ay, float* az);
     void zeroCalibrate(unsigned int samples, unsigned int sampleDelayMS);
 };


### PR DESCRIPTION
The data type of variable "x_offset_temp","y_offset_temp", "z_offset_temp" is "int16_t" in the origin version. If the parameter "samples" of member function "ITG3200::zeroCalibrate(unsingned int,unsigned int)“ is too big(even only 400!), it may cause overflow when summing up the offsets, which cause the offset calculated by offset_temp is wrong(often is a number with the reverse sign). As the result, the xyzs output from the function getXYZ have a bigger offset than before.
I change the data type into "long" or "int" to expand its range which can avoid the overflow. And it works when I set the "samples" as 800.
`long x_offset_temp = 0;
    long y_offset_temp = 0;
    long z_offset_temp = 0;
    long x, y, z;`

该库中用于零位校准的"ITG3200::zeroCalibrate(unsingned int,unsigned int)“函数中的`"x_offset_temp,y_offset_temp,z_offset_temp`变量的数据类型是int16_t，只有16位，最大范围为只有三万左右。在取样数量samples过大再加上陀螺仪存在固有的误差情况下容易造成变量数据溢出，若每次测量偏差offset为正，则溢出后偏差和将会变成负数，求平均存入offset变量后反而加大了陀螺仪输出数据的偏差。因此将上述三个变量的数据类型改为long，以适应更大的取样数要求。